### PR TITLE
feat(Keep) 更新提示（取消 matchTime）

### DIFF
--- a/src/apps/com.gotokeep.keep.ts
+++ b/src/apps/com.gotokeep.keep.ts
@@ -75,7 +75,6 @@ export default defineAppConfig({
       name: '更新提示',
       desc: '点击"暂不升级"',
       quickFind: true,
-      matchTime: 10000,
       actionMaximum: 1,
       resetMatch: 'app',
       rules: [


### PR DESCRIPTION
更新弹窗并不总是在打开app立即出现，有时候在训练完成返回首页时弹出，此时距离上次 `resetMatch` 的时间已经远大于10s。

此外，更新提示的规则 `[id="com.gotokeep.keep:id/text_secondary_action"]` 不太容易误触，没有使用 `matchTime` 的必要。

综上，移除 `matchTime`。