### PR TITLE
perf(Reddit): 其他-关闭订阅社区消息提示

### DIFF
--- a/src/apps/com.reddit.frontpage.ts
+++ b/src/apps/com.reddit.frontpage.ts
@@ -6,15 +6,19 @@ export default defineGkdApp({
   groups: [
     {
       key: 3,
-      name: '更新提示-社区消息',
+      name: '其他-关闭订阅社区消息提示',
+      desc: '自动点击[Not Now]',
       fastQuery: true,
-      matchTime: 10000,
-      actionMaximum: 1,
-      resetMatch: 'app',
       rules: [
         {
-          matches: '[id="com.reddit.frontpage:id/cancel_button"]',
-          snapshotUrls: 'https://i.gkd.li/i/13649914',
+          activityIds: 'com.reddit.launch.main.MainActivity',
+          matches:
+            '[vid="sheet_container"] > [vid="cancel_button"][text="Not Now"][clickable=true]',
+          snapshotUrls: [
+            'https://i.gkd.li/i/13649914',
+            'https://i.gkd.li/i/17269009',
+          ],
+          exampleUrls: 'https://e.gkd.li/b640f2c9-4564-420f-8a2f-20f461032f3d',
         },
       ],
     },

--- a/src/globalDefaultApps.ts
+++ b/src/globalDefaultApps.ts
@@ -112,6 +112,7 @@ export const blackListAppIDs: string[] = [
   'me.iacn.biliroaming', // 哔哩漫游
   'com.termux', // Termux
   'oss.krtirtho.spotube', // Spotube
+  'com.reddit.frontpage', // Reddit
 
   'com.canghai.haoka',
   'com.xy.td',


### PR DESCRIPTION
看到这个规则的`name`感觉挺疑惑的，显然不属于“更新提示”，但是参数之类的像是更新提示。于是翻了一下commit。最初的name是`社区消息-更新提示`，后来被改成了`更新提示-社区消息`，然后规则的参数似乎向着“更新提示”的方向去了。囧……