### PR TITLE
feat(哔哩哔哩): 局部广告-搜索结果广告

### DIFF
--- a/src/apps/tv.danmaku.bili.ts
+++ b/src/apps/tv.danmaku.bili.ts
@@ -330,21 +330,22 @@ export default defineGkdApp({
     },
     {
       key: 14,
-      name: '局部广告-搜索结果广告',
-      desc: '点击不感兴趣',
+      name: '分段广告-搜索结果广告',
+      desc: '点击右下角[菜单]-点击[不感兴趣]',
       fastQuery: true,
-      matchDelay: 5000,
       activityIds: 'com.bilibili.search2.main.BiliMainSearchActivity',
       rules: [
         {
           key: 1,
           matches:
-            '[id="tv.danmaku.bili:id/desc"][vid="desc"][clickable=false] < * -1 *[clickable=true]',
+            '@[vid="more"][clickable=true][visibleToUser=true] -3 [vid="tag_layout"] > [vid="ad_tag_with_dot"]',
+          exampleUrls: 'https://e.gkd.li/e5dd30e7-e8dd-42bc-8953-23368e65cca4',
           snapshotUrls: 'https://i.gkd.li/i/17269053',
         },
         {
-          preKeys: 1,
-          matches: '[text="不感兴趣"] < *',
+          preKeys: [1],
+          matches: '@[clickable=true] > [text="不感兴趣"]',
+          exampleUrls: 'https://e.gkd.li/5e6e4b69-ba97-473d-9f62-631c296da589',
           snapshotUrls: 'https://i.gkd.li/i/17269055',
         },
       ],

--- a/src/apps/tv.danmaku.bili.ts
+++ b/src/apps/tv.danmaku.bili.ts
@@ -328,5 +328,26 @@ export default defineGkdApp({
         },
       ],
     },
+    {
+      key: 14,
+      name: '局部广告-搜索结果广告',
+      desc: '点击不感兴趣',
+      fastQuery: true,
+      matchDelay: 5000,
+      activityIds: 'com.bilibili.search2.main.BiliMainSearchActivity',
+      rules: [
+        {
+          key: 1,
+          matches:
+            '[id="tv.danmaku.bili:id/desc"][vid="desc"][clickable=false] < * -1 *[clickable=true]',
+          snapshotUrls: 'https://i.gkd.li/i/17269053',
+        },
+        {
+          preKeys: 1,
+          matches: '[text="不感兴趣"] < *',
+          snapshotUrls: 'https://i.gkd.li/i/17269055',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
哔哩哔哩搜索结果穿插有广告，本pr自动选中广告对应搜索条目并点击“不感兴趣”，已在物理机上测试对应规则。

相关snapshotUrls:
- https://i.gkd.li/i/17269053
- https://i.gkd.li/i/17269055