### PR TITLE
fix(数字人民币): 更新提示 (限制文本)

### DIFF
--- a/src/apps/cn.gov.pbc.dcep.ts
+++ b/src/apps/cn.gov.pbc.dcep.ts
@@ -10,8 +10,9 @@ export default defineGkdApp({
       fastQuery: true,
       actionMaximum: 1,
       resetMatch: 'app',
-      rules: '[vid="upgrade_dialog_cancel"]',
+      rules: '[vid="upgrade_dialog_cancel"][text!="退出应用"]',
       snapshotUrls: 'https://i.gkd.li/i/13840408',
+      excludeSnapshotUrls: 'https://i.gkd.li/i/17607391',
     },
   ],
 });


### PR DESCRIPTION
限制 `[vid="upgrade_dialog_cancel"]` 按钮的 `text` 属性，防止在版本太旧，app 强制更新的时候点击 `退出应用`