### PR TITLE
feat(自如): 全屏弹窗广告；推荐好友弹窗

### DIFF
--- a/src/apps/com.ziroom.ziroomcustomer.ts
+++ b/src/apps/com.ziroom.ziroomcustomer.ts
@@ -1,0 +1,48 @@
+import { defineGkdApp } from '@gkd-kit/define';
+
+export default defineGkdApp({
+  id: 'com.ziroom.ziroomcustomer',
+  name: '自如',
+  groups: [
+    {
+      key: 1,
+      name: '全屏弹窗广告',
+      fastQuery: true,
+      actionMaximum: 1,
+      resetMatch: 'app',
+      rules: [
+        {
+          key: 0,
+          name: '点击叉号关闭',
+          activityIds: [
+            '.MainActivity',
+          ],
+          matches: ['[text*="本弹窗由自如推送"] + * > [vid="tv_ok"]'],
+          snapshotUrls: [
+            'https://i.gkd.li/i/18373198',
+          ],
+        },
+      ],
+    },
+    {
+      key: 2,
+      name: '推荐好友弹窗',
+      fastQuery: true,
+      actionMaximum: 1,
+      resetMatch: 'app',
+      activityIds: [
+        '.MainActivity',
+      ],
+      rules: [
+        {
+          key: 0,
+          name: '点击叉号关闭',
+          matches: ['[text*="向亲朋好友推荐自如"] + [vid="iv_nps_close"]'],
+          snapshotUrls: [
+            'https://i.gkd.li/i/18373218',
+          ],
+        },
+      ],
+    },
+  ],
+});

--- a/src/apps/com.ziroom.ziroomcustomer.ts
+++ b/src/apps/com.ziroom.ziroomcustomer.ts
@@ -6,41 +6,34 @@ export default defineGkdApp({
   groups: [
     {
       key: 1,
-      name: '全屏弹窗广告',
-      fastQuery: true,
+      name: '全屏广告-弹窗广告',
+      desc: '点击关闭',
+      matchTime: 10000,
       actionMaximum: 1,
       resetMatch: 'app',
       rules: [
         {
-          key: 0,
-          name: '点击叉号关闭',
-          activityIds: [
-            '.MainActivity',
-          ],
-          matches: ['[text*="本弹窗由自如推送"] + * > [vid="tv_ok"]'],
-          snapshotUrls: [
-            'https://i.gkd.li/i/18373198',
-          ],
+          fastQuery: true,
+          activityIds: '.MainActivity',
+          matches: '[vid="tv_ok"][visibleToUser=true]',
+          exampleUrls: 'https://e.gkd.li/c6507af4-1bb2-4c39-ab5d-3d04ec391291',
+          snapshotUrls: 'https://i.gkd.li/i/18373198',
         },
       ],
     },
     {
       key: 2,
-      name: '推荐好友弹窗',
-      fastQuery: true,
+      name: '全屏广告-推荐好友弹窗',
+      desc: '点击关闭',
       actionMaximum: 1,
       resetMatch: 'app',
-      activityIds: [
-        '.MainActivity',
-      ],
       rules: [
         {
-          key: 0,
-          name: '点击叉号关闭',
-          matches: ['[text*="向亲朋好友推荐自如"] + [vid="iv_nps_close"]'],
-          snapshotUrls: [
-            'https://i.gkd.li/i/18373218',
-          ],
+          fastQuery: true,
+          activityIds: '.MainActivity',
+          matches: '[vid="iv_nps_close"][visibleToUser=true]',
+          exampleUrls: 'https://e.gkd.li/808f8c61-211f-4592-abe5-21467c133ba6',
+          snapshotUrls: 'https://i.gkd.li/i/18373218',
         },
       ],
     },


### PR DESCRIPTION
提交的时候Actions有错误，不知道这个是什么原因，烦请告知一下，以后避免
```
/home/runner/work/GKD_subscription/GKD_subscription/node_modules/.pnpm/@gkd-kit+tools@0.5.2_@gkd-kit+api@0.6.0_json5@2.2.3/node_modules/@gkd-kit/tools/dist/index.mjs:804
        throw new Error(
              ^


Error: Invalid group: 全屏弹窗广告, key=1 not match any category in subscription[id=666,name=AIsouler的GKD订阅] app[id=com.ziroom.ziroomcustomer,name=自如]
    at <anonymous> (/home/runner/work/GKD_subscription/GKD_subscription/node_modules/.pnpm/@gkd-kit+tools@0.5.2_@gkd-kit+api@0.6.0_json5@2.2.3/node_modules/@gkd-kit/tools/dist/index.mjs:804:15)
    at Array.forEach (<anonymous>)
    at <anonymous> (/home/runner/work/GKD_subscription/GKD_subscription/node_modules/.pnpm/@gkd-kit+tools@0.5.2_@gkd-kit+api@0.6.0_json5@2.2.3/node_modules/@gkd-kit/tools/dist/index.mjs:800:17)
    at Array.forEach (<anonymous>)
    at checkCategory (/home/runner/work/GKD_subscription/GKD_subscription/node_modules/.pnpm/@gkd-kit+tools@0.5.2_@gkd-kit+api@0.6.0_json5@2.2.3/node_modules/@gkd-kit/tools/dist/index.mjs:799:22)
    at checkSubscription (/home/runner/work/GKD_subscription/GKD_subscription/node_modules/.pnpm/@gkd-kit+tools@0.5.2_@gkd-kit+api@0.6.0_json5@2.2.3/node_modules/@gkd-kit/tools/dist/index.mjs:815:3)
    at <anonymous> (/home/runner/work/GKD_subscription/GKD_subscription/scripts/check.ts:5:1)

Node.js v22.[12](https://github.com/scalpelx/GKD_subscription/actions/runs/12707721178/job/35423214237#step:6:13).0
 ELIFECYCLE  Command failed with exit code 1.
```