### PR TITLE
fix: 向日葵分段广告

### DIFF
--- a/src/apps/com.oray.sunlogin.ts
+++ b/src/apps/com.oray.sunlogin.ts
@@ -94,7 +94,6 @@ export default defineGkdApp({
         },
         {
           preKeys: [0],
-          action: 'clickCenter', // clickNode 可能无效
           matches: '[text="不感兴趣"][visibleToUser=true]',
           exampleUrls: 'https://e.gkd.li/55f927c7-edb5-4324-a73a-ad6dfa090eb6',
           snapshotUrls: 'https://i.gkd.li/i/22865433',


### PR DESCRIPTION
向日葵-分段广告-点击不感兴趣这一步无需使用 `clickCenter` ，默认的 `clickNode` 永远可以生效。 这一步使用 `clickCenter` 反而会出现误触，因为点击 `X` 后 “不感兴趣” 这个对话框是逐渐弹起的，有时候会点击到 “不感兴趣” 以外的按钮