### PR TITLE
feat: 系统界面-功能类-允许网易云音乐共享整个屏幕 等2个更新

### DIFF
--- a/src/apps/com.android.systemui.ts
+++ b/src/apps/com.android.systemui.ts
@@ -6,42 +6,29 @@ export default defineGkdApp({
   groups: [
     {
       key: 1,
-      name: '功能类-允许网易云音乐共享整个屏幕',
+      name: '功能类-自动允许网易云音乐共享整个屏幕',
+      fastQuery: true,
+      activityIds:
+        '.mediaprojection.permission.MediaProjectionPermissionActivity',
       rules: [
         {
           key: 1,
-          fastQuery: true,
-          activityIds:
-            '.mediaprojection.permission.MediaProjectionPermissionActivity',
           matches: [
             '[text="要与“网易云音乐”共享屏幕吗？"]',
-            '[text="共享一个应用"] < [vid="screen_share_mode_spinner"][clickable=true]',
+            '[vid="screen_share_mode_spinner"][clickable=true]',
           ],
           snapshotUrls: 'https://i.gkd.li/i/23451390',
         },
         {
           preKeys: [1],
           key: 2,
-          fastQuery: true,
-          activityIds:
-            '.mediaprojection.permission.MediaProjectionPermissionActivity',
-          matches: [
-            '[text="共享一个应用"]',
-            '@[clickable=true] > [text="共享整个屏幕"]',
-          ],
+          matches: '@[clickable=true] > [text="共享整个屏幕"]',
           snapshotUrls: 'https://i.gkd.li/i/23451403',
         },
         {
           preKeys: [2],
           key: 3,
-          fastQuery: true,
-          activityIds:
-            '.mediaprojection.permission.MediaProjectionPermissionActivity',
-          matches: [
-            '[text="要与“网易云音乐”共享屏幕吗？"]',
-            '[text="共享整个屏幕"] < [vid="screen_share_mode_spinner"]',
-            'Button[text="共享屏幕"][clickable=true]',
-          ],
+          matches: 'Button[text="共享屏幕"][clickable=true]',
           snapshotUrls: 'https://i.gkd.li/i/23451416',
         },
       ],
@@ -49,41 +36,28 @@ export default defineGkdApp({
     {
       key: 2,
       name: '功能类-允许白描共享整个屏幕',
+      fastQuery: true,
+      activityIds:
+        '.mediaprojection.permission.MediaProjectionPermissionActivity',
       rules: [
         {
           key: 1,
-          fastQuery: true,
-          activityIds:
-            '.mediaprojection.permission.MediaProjectionPermissionActivity',
           matches: [
             '[text="要与“白描”共享屏幕吗？"]',
-            '[text="共享一个应用"] < [vid="screen_share_mode_spinner"][clickable=true]',
+            '[vid="screen_share_mode_spinner"][clickable=true]',
           ],
           snapshotUrls: 'https://i.gkd.li/i/23451390',
         },
         {
           preKeys: [1],
           key: 2,
-          fastQuery: true,
-          activityIds:
-            '.mediaprojection.permission.MediaProjectionPermissionActivity',
-          matches: [
-            '[text="共享一个应用"]',
-            '@[clickable=true] > [text="共享整个屏幕"]',
-          ],
+          matches: '@[clickable=true] > [text="共享整个屏幕"]',
           snapshotUrls: 'https://i.gkd.li/i/23451403',
         },
         {
           preKeys: [2],
           key: 3,
-          fastQuery: true,
-          activityIds:
-            '.mediaprojection.permission.MediaProjectionPermissionActivity',
-          matches: [
-            '[text="要与“白描”共享屏幕吗？"]',
-            '[text="共享整个屏幕"] < [vid="screen_share_mode_spinner"]',
-            'Button[text="共享屏幕"][clickable=true]',
-          ],
+          matches: 'Button[text="共享屏幕"][clickable=true]',
           snapshotUrls: 'https://i.gkd.li/i/23451416',
         },
       ],


### PR DESCRIPTION
白描是一款图片转文字的软件。
网易云音乐将此权限用于戴耳机时对其他应用播放的声音进行听歌识曲。