### PR TITLE
feat: 番喜视频 开屏广告

### DIFF
--- a/src/apps/com.oidalmn.donrv.ts
+++ b/src/apps/com.oidalmn.donrv.ts
@@ -5,6 +5,23 @@ export default defineGkdApp({
   name: '番喜视频',
   groups: [
     {
+      key: 0,
+      name: '开屏广告',
+      desc: '仅为全局开屏广告的单独补充',
+      matchTime: 10000,
+      actionMaximum: 1,
+      resetMatch: 'app',
+      priorityTime: 10000,
+      rules: [
+        {
+          matches:
+            'FrameLayout[index=parent.childCount.minus(1)] > ImageView[width>52 && width<64][height>52 && height<64][top>1000]',
+          snapshotUrls: 'https://i.gkd.li/i/24377039', //v1.8.7 广告的x号在下半方屏幕的
+          activityIds: '.MainActivity',
+        },
+      ],
+    },
+    {
       key: 1,
       name: '全屏广告-弹窗广告',
       desc: '点击关闭',


### PR DESCRIPTION
新增 '番喜视频' 的开屏广告，算是`全局的开屏广告`的额外补充，单单在番喜视频app生效。

#1648