### PR TITLE
feat: 得间免费小说 广告适配等

### DIFF
--- a/src/apps/com.chaozh.iReader.dj.ts
+++ b/src/apps/com.chaozh.iReader.dj.ts
@@ -5,119 +5,97 @@ export default defineGkdApp({
   name: '得间免费小说',
   groups: [
     {
-      key: 0,
-      name: '局部广告-小说内下方悬浮广告',
-      fastQuery: true,
-      actionDelay: 300,
-      activityIds: 'com.zhangyue.iReader.read.ui.Activity_BookBrowser_TXT',
+      key: 1,
+      name: '局部广告',
       rules: [
         {
+          key: 1,
+          fastQuery: true,
+          activityIds: [
+            'com.qq.e.ads.PortraitADActivity',
+            'com.zhangyue.iReader.read.ui.Activity_BookBrowser_TXT',
+          ],
           matches:
-            '@ImageView[id="com.zhangyue.module.ad:id/ad_close_2"][width=45 && height=24]',
+            '@[id*="ad_close"] - LinearLayout >(5,6) [text="广告"][visibleToUser=true]',
           snapshotUrls: [
             'https://i.gkd.li/i/24879639',
             'https://i.gkd.li/i/24879692',
             'https://i.gkd.li/i/24879766',
           ],
         },
-      ],
-    },
-    {
-      key: 1,
-      name: '功能类-首页悬浮小红包',
-      desc: '关掉它',
-      fastQuery: true,
-      activityIds: 'com.zhangyue.iReader.bookshelf.ui.ActivityBookShelf',
-      rules: [
         {
-          matches: '@ImageView < FrameLayout <2 [id="android:id/content"]',
+          key: 2,
+          fastQuery: true,
+          activityIds: 'com.zhangyue.iReader.bookshelf.ui.ActivityBookShelf',
+          matches:
+            '@ImageView[clickable=true][childCount=0][width<50 && height<50] < FrameLayout <2 [id="android:id/content"]',
           snapshotUrls: [
             'https://i.gkd.li/i/24880989',
             'https://i.gkd.li/i/24881759',
           ],
         },
-      ],
-    },
-    {
-      key: 2,
-      name: '局部广告-听书播放器底部广告',
-      fastQuery: true,
-      activityIds: 'com.zhangyue.iReader.ui.activity.ActivityContainer',
-      rules: [
         {
-          matches:
-            '[id="com.zhangyue.module.ad:id/close"][text="关闭"][width=66 && height=45]',
-          snapshotUrls: [
-            'https://i.gkd.li/i/24885529',
-            'https://i.gkd.li/i/24884414',
-            'https://i.gkd.li/i/24882622',
-          ],
-        },
-      ],
-    },
-    {
-      key: 3,
-      name: '局部广告-书籍阅读页间断插入广告', //可点击，但是容易被骗。。。
-      fastQuery: true,
-      rules: [
-        {
-          key: 0,
-          name: '中间单容器单广告',
-          activityIds: 'com.zhangyue.iReader.read.ui.Activity_BookBrowser_TXT',
-          matches:
-            '@ImageView[id="com.zhangyue.module.ad:id/close"][width<25 && height<25]',
-          snapshotUrls: [
-            'https://i.gkd.li/i/24882824',
-            'https://i.gkd.li/i/24882944',
-            'https://i.gkd.li/i/24887834', //真机测试发现钓鱼假x关闭按钮3个，一旦点击会弹出两个层叠充值会员页面
-            'https://i.gkd.li/i/24888200', //结果图
-            'https://i.gkd.li/i/24888204',
-          ],
-        },
-        {
-          key: 1,
-          name: '大卡片广告',
+          key: 3,
+          fastQuery: true,
           activityIds: [
-            'com.qq.e.ads.PortraitADActivity',
+            'com.zhangyue.iReader.ui.activity.ActivityContainer',
+            'com.zhangyue.iReader.bookshelf.ui.ActivityBookShelf',
             'com.zhangyue.iReader.read.ui.Activity_BookBrowser_TXT',
           ],
-          matches: '[text="关闭"][width<80 && height<50][clickable=true]',
+          matches:
+            '@[text="关闭"][clickable=true] <<n [id="com.zhangyue.module.ad:id/mix_ad_view" || id="com.zhangyue.module.ad:id/ad_splash_ad_layout"]',
           snapshotUrls: [
+            'https://i.gkd.li/i/24884414',
+            'https://i.gkd.li/i/24882622',
             'https://i.gkd.li/i/24883183',
-            'https://i.gkd.li/i/24883422',
-            'https://i.gkd.li/i/24884108',
           ],
         },
-      ],
-    },
-    {
-      key: 4,
-      name: '局部广告-短剧底部广告',
-      fastQuery: true,
-      activityIds:
-        'com.zhangyue.app.shortplay.player.ui.activity.EpisodesSetPlayActivity',
-      rules: [
         {
-          matches: '[id="com.zhangyue.module.ad:id/close_ad"]',
+          key: 4,
+          fastQuery: true,
+          activityIds: 'com.qq.e.ads.PortraitADActivity',
+          matches:
+            '[text$="了解更多"] <<n [id="android:id/content"] + [text="关闭"][clickable=true][visibleToUser=true]',
+          snapshotUrls: 'https://i.gkd.li/i/24909685',
+        },
+        {
+          key: 5,
+          fastQuery: true,
+          activityIds: [
+            'com.zhangyue.app.shortplay.player.ui.activity.EpisodesSetPlayActivity',
+            'com.zhangyue.iReader.read.ui.Activity_BookBrowser_TXT',
+          ],
+          matches:
+            '[id="com.zhangyue.module.ad:id/close_ad" || id="com.zhangyue.module.ad:id/ad_close_2"]',
           snapshotUrls: [
-            'https://i.gkd.li/i/24885711',
             'https://i.gkd.li/i/24885716',
-            'https://i.gkd.li/i/24885714',
+            'https://i.gkd.li/i/24888022',
           ],
         },
       ],
     },
-    {
-      key: 5,
-      name: '局部广告-小说结尾横幅小广告',
-      fastQuery: true,
-      activityIds: 'com.zhangyue.iReader.read.ui.Activity_BookBrowser_TXT',
-      rules: [
-        {
-          matches: '[id="com.zhangyue.module.ad:id/ad_close_2"]',
-          snapshotUrls: 'https://i.gkd.li/i/24888022',
-        },
-      ],
-    },
+
+    // 存在无法解决的误触问题
+    // {
+    //   key: 3,
+    //   name: '局部广告-书籍阅读页间断插入广告', //可点击，但是容易被骗。。。
+    //   fastQuery: true,
+    //   rules: [
+    //     {
+    //       key: 0,
+    //       name: '中间单容器单广告',
+    //       activityIds: 'com.zhangyue.iReader.read.ui.Activity_BookBrowser_TXT',
+    //       matches:
+    //         '@ImageView[id="com.zhangyue.module.ad:id/close"][width<25 && height<25]',
+    //       snapshotUrls: [
+    //         'https://i.gkd.li/i/24882824',
+    //         'https://i.gkd.li/i/24882944',
+    //         'https://i.gkd.li/i/24887834', //真机测试发现钓鱼假x关闭按钮3个，一旦点击会弹出两个层叠充值会员页面
+    //         'https://i.gkd.li/i/24888200', //结果图
+    //         'https://i.gkd.li/i/24888204',
+    //       ],
+    //     },
+    //   ],
+    // },
   ],
 });


### PR DESCRIPTION
# 真机测试适配报告

## 测试结果概览
| 测试项目                        | 状态   | 备注              |
| ------------------------------- | ------ | ----------------- |
| 局部广告-小说内下方悬浮广告     | ✅ PASS | -                 |
| 功能类-首页悬浮小红包           | ✅ PASS | -                 |
| 局部广告-听书播放器底部广告     | ✅ PASS | -                 |
| 局部广告-书籍阅读页间断插入广告 | ❌ ERR! | **被反GDK措施？** |
| 局部广告-短剧底部广告           | ✅ PASS | -                 |
| 局部广告-小说结尾横幅小广告     | ✅ PASS | -                 |

---

## 以及一些规则尚未预期成功

### 1. 局部广告-听书播放器中央广告
```ts
    {
      key: 0,
      name: '局部广告-听书播放器中央广告',  //尚未实现[clickable=false]，无靶点，待进一步分析……
      fastQuery: true, 
      activityIds: 'com.zhangyue.iReader.ui.activity.ActivityContainer',
      rules: [
        {
          matches: '@TextView <3 LinearLayout <2 FrameLayout <2 FrameLayout < FrameLayout < RecyclerView <2 ViewGroup <2 LinearLayout < RelativeLayout < FrameLayout < FrameLayout < [id="android:id/content"]',
          snapshotUrls: [
            'https://i.gkd.li/i/24886349',
            'https://i.gkd.li/i/24886377',
          ],
        },
      ],
    }
```

### 2. 观看广告奖励页自动点击跳过

- **状态**：尚未实现

- **备注**：似乎被写死了……

- **参考快照**：
  
  - https://i.gkd.li/i/24886760
  
  - https://i.gkd.li/i/24886758
  
### 3.<u>书籍阅读页间断插入广告</u>小分支规则

```ts
        {
          key: 0,
          name: '小说内间隔性广告-中间多容器多广告',
          activityIds: 'com.qq.e.ads.PortraitADActivity', 
          matches: '',
          snapshotUrls: [
            'https://i.gkd.li/i/24886997',
            'https://i.gkd.li/i/24887025',
          ],
        }
```

### 4. 局部广告-短剧间断插播广告
```json
{
  "key": 0,
  "name": "局部广告-短剧间断插播广告",
  "fastQuery": true,
  "activityIds": "com.chaozh.iReader.dj",
  "rules": [
    {
      "matches": "[text=\"上滑继续看短剧\"][id=\"com.zhangyue.module.ad:id/btl_tv_tips\"]",
      "snapshotUrls": [
        "https://i.gkd.li/i/24887248",
        "https://i.gkd.li/i/24887244"
      ]
    }
  ]
}
```
- **API限制**？：似乎无法实现**上滑**功能

---

## 针对<u>书籍阅读页间断插入广告</u>反诈措施测试
### 全屏广告-小说内充值会员页面
```json
{
  "key": 6,
  "name": "全屏广告-小说内充值会员页面",
  "备注": "对假取消反诈措施-仅治标",
  "fastQuery": true,
  "activityIds": "com.zhangyue.iReader.online.ui.ActivityFee",
  "rules": [
    {
      "matches": "\"似乎没有目标可使用\"",
      "snapshotUrls": [
        "https://i.gkd.li/i/24888200",
        "https://i.gkd.li/i/24888204"
      ]
    }
  ]
}
```
- **结果**：**反诈失败** ❌

局部广告-书籍阅读页间断插入广告 当时情况

https://github.com/user-attachments/assets/51e9703f-08d9-4dd9-a0a7-4ae525d1ca33

