### PR TITLE
fix: 更改逻辑为关系寻找通知并关闭

### DIFF
--- a/src/apps/com.jiongji.andriod.card.ts
+++ b/src/apps/com.jiongji.andriod.card.ts
@@ -57,13 +57,13 @@ export default defineGkdApp({
     },
     {
       key: 4,
-      name: '通知提示-关闭顶栏提醒💡',
+      name: '通知提示-关闭顶栏提醒',
       rules: [
         {
           fastQuery: true,
           activityIds: 'com.baicizhan.main.activity.MainTabActivity',
           matches:
-            '[desc="word_plan_tab"] > FrameLayout > ViewGroup > ImageView +2 ImageView',
+            '[desc="word_plan_tab"] > FrameLayout[index=2] >2 TextView[text!=null] + ImageView[clickable=true][childCount=0][index=parent.childCount.minus(1)]',
           snapshotUrls: [
             'https://i.gkd.li/i/24887224',
             'https://i.gkd.li/i/24983406',


### PR DESCRIPTION
考虑容器都是随机的id，一开始想用底栏[text="我"]作为描点往外面推再定位横幅容器去找，但是太长且万一加容器容易废，所以我找[desc="word_plan_tab"]作为描点来往里推，我觉得这个‘靶点’容器应该不会有变化

fixe: #1780 