### PR TITLE
feat: MT管理器-增加开屏广告全局黑名单

### DIFF
--- a/src/globalDefaultApps.ts
+++ b/src/globalDefaultApps.ts
@@ -322,6 +322,7 @@ export const openAdBlackListAppIDs = new Set([
   ...blackListAppIDs,
   'com.taptap', // TapTap
   'com.sankuai.meituan', // 美团 误触 https://i.gkd.li/i/17827264
+  'bin.mt.plus', // MT管理器
 ]);
 
 // 更新提示黑名单


### PR DESCRIPTION
更新提示包含“跳过”按钮，目前手上没有快照