### PR TITLE
fix: OurPlay 全屏广告-弹窗广告

### DIFF
--- a/src/apps/com.excean.gspace.ts
+++ b/src/apps/com.excean.gspace.ts
@@ -49,9 +49,18 @@ export default defineGkdApp({
         {
           key: 2,
           fastQuery: true,
-          activityIds: 'com.excelliance.kxqp.gs.main.MainActivity',
-          matches: '[vid="close_render_ad"]',
-          snapshotUrls: 'https://i.gkd.li/i/15284762',
+          activityIds: [
+            'com.excelliance.kxqp.gs.main.MainActivity',
+            'com.smartdigimkt.sdk.basead.ui.ATPortraitTranslucentActivity',
+            'com.anythink.core.common.inner.ui.ATPortraitTranslucentActivity',
+          ],
+          matches:
+            '[vid="close_render_ad" || vid="sdm_myoffer_btn_close_id" || vid="anythink_myoffer_btn_close_id"][clickable=true]',
+          snapshotUrls: [
+            'https://i.gkd.li/i/15284762',
+            'https://i.gkd.li/i/24611979',
+            'https://i.gkd.li/i/25187840',
+          ],
         },
         {
           key: 3,
@@ -72,12 +81,12 @@ export default defineGkdApp({
           snapshotUrls: 'https://i.gkd.li/i/24464957',
         },
         {
-          key: 5,
-          fastQuery: true,
+          key: 6,
           activityIds:
-            'com.smartdigimkt.sdk.basead.ui.ATPortraitTranslucentActivity',
-          matches: '[vid="sdm_myoffer_btn_close_id"][visibleToUser=true]',
-          snapshotUrls: 'https://i.gkd.li/i/24611979',
+            'com.sigmob.sdk.base.common.PortraitTransparentAdActivity',
+          matches:
+            '@TextView[text=""][width<90 && height<90] < View[childCount=1] - View > [text="反馈"][visibleToUser=true]',
+          snapshotUrls: 'https://i.gkd.li/i/25188505',
         },
       ],
     },

--- a/src/apps/com.excean.gspace.ts
+++ b/src/apps/com.excean.gspace.ts
@@ -86,7 +86,7 @@ export default defineGkdApp({
             'com.sigmob.sdk.base.common.PortraitTransparentAdActivity',
           matches:
             '@TextView[text=""][width<90 && height<90] < View[childCount=1] - View > [text="反馈"][visibleToUser=true]',
-          snapshotUrls: 'https://i.gkd.li/i/25188505',
+          snapshotUrls: 'https://i.gkd.li/i/25202925',
         },
       ],
     },


### PR DESCRIPTION
resolves #1859

原先的`子key5` 和 `一个新的` 合并到 `子key2`里。

有两个开屏广告在全局那里已经有适配了的，快照：`https://i.gkd.li/i/25188613`  ，`https://i.gkd.li/i/25188611` 。

这哥们发了一堆快照，看了半天只有两个是没适配的😵，中途梯子还不稳定。