### PR TITLE
feat: 小红书 局部广告-直播间各种卡片&关闭首页信息流中推荐博主&你可能感兴趣的人

### DIFF
--- a/src/apps/com.xingin.xhs.ts
+++ b/src/apps/com.xingin.xhs.ts
@@ -222,21 +222,11 @@ export default defineGkdApp({
       activityIds: 'com.xingin.alpha.audience.v2.AlphaAudienceActivityV2',
       rules: [
         {
-          key: 0,
-          actionMaximum: 1,
-          matches:
-            '@ViewGroup[childCount=2][clickable=true][visibleToUser=true] <<7 [vid="infoCardViewPager"]',
-          snapshotUrls: [
-            'https://i.gkd.li/i/25244875', //右上角卡片
-            'https://i.gkd.li/i/25244996',
-          ],
-        },
-        {
           key: 1,
           fastQuery: true,
           matches:
-            '@ViewGroup[clickable=true][visibleToUser=true] - ViewGroup <<4 [vid="canvasLayout"]',
-          snapshotUrls: 'https://i.gkd.li/i/25245250', //右下角橱窗卡片广告
+            '@ViewGroup[clickable=true][visibleToUser=true] - ViewGroup <<n [vid="canvasLayout"]',
+          snapshotUrls: 'https://i.gkd.li/i/25245250',
         },
       ],
     },

--- a/src/apps/com.xingin.xhs.ts
+++ b/src/apps/com.xingin.xhs.ts
@@ -191,5 +191,54 @@ export default defineGkdApp({
         },
       ],
     },
+    {
+      key: 7,
+      name: '局部广告-你可能感兴趣的人',
+      rules: [
+        {
+          fastQuery: true,
+          activityIds: 'com.xingin.xhs.index.v2.IndexActivityV2',
+          matches: '[text="你可能感兴趣的人"] +2 Button[text="关闭"]',
+          snapshotUrls: 'https://i.gkd.li/i/25244655',
+        },
+      ],
+    },
+    {
+      key: 8,
+      name: '局部广告-关闭首页信息流中推荐博主',
+      rules: [
+        {
+          fastQuery: true,
+          activityIds: 'com.xingin.xhs.index.v2.IndexActivityV2',
+          matches:
+            '[vid="recommend_close"][clickable=true][visibleToUser=true]',
+          snapshotUrls: 'https://i.gkd.li/i/25245325',
+        },
+      ],
+    },
+    {
+      key: 9,
+      name: '局部广告-直播间各种卡片',
+      activityIds: 'com.xingin.alpha.audience.v2.AlphaAudienceActivityV2',
+      rules: [
+        {
+          key: 0,
+          actionMaximum: 1,
+          matches:
+            '@ViewGroup[childCount=2][clickable=true][visibleToUser=true] <<7 [vid="infoCardViewPager"]',
+          snapshotUrls: [
+            'https://i.gkd.li/i/25244875', //右上角卡片
+            'https://i.gkd.li/i/25244996',
+          ],
+        },
+        {
+          key: 1,
+          fastQuery: true,
+          matches:
+            '@ViewGroup[clickable=true][visibleToUser=true] - ViewGroup <<4 [vid="canvasLayout"]',
+          snapshotUrls: 'https://i.gkd.li/i/25245250', //右下角橱窗卡片广告
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## 在key9中的key0选择器里有支持快速查询的控件为什么生成配置中没添加快速查询参数？还是说支持快速查询的控件必须在前面

![1](https://github.com/user-attachments/assets/b38242de-6604-4caa-b3b4-b0fb8fb91a9f)
